### PR TITLE
Add SupportsReportStatistics to SeqDSv2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.gwalid</groupId>
     <artifactId>seq-datasource-v2</artifactId>
-    <version>0.1.0-dev1</version>
+    <version>0.1.1-dev1</version>
 
 
     <properties>
@@ -112,6 +112,8 @@
                 </configuration>
                 <executions>
                     <execution>
+                        <id>style-check</id>
+                        <phase>test</phase>
                         <goals>
                             <goal>check</goal>
                         </goals>

--- a/src/main/scala/org/gwalid/seq/datasource/v2/SeqDataSourceStatistics.scala
+++ b/src/main/scala/org/gwalid/seq/datasource/v2/SeqDataSourceStatistics.scala
@@ -1,0 +1,14 @@
+package org.gwalid.seq.datasource.v2
+
+import java.util.OptionalLong
+
+import org.apache.spark.sql.sources.v2.reader.Statistics
+
+class SeqDataSourceStatistics(size: Long, numRows: Long) extends Statistics {
+
+  override def sizeInBytes(): OptionalLong = OptionalLong.of(size)
+
+  override def numRows(): OptionalLong = OptionalLong.of(numRows)
+
+
+}

--- a/src/main/scala/org/gwalid/seq/datasource/v2/SeqInputFileIO.scala
+++ b/src/main/scala/org/gwalid/seq/datasource/v2/SeqInputFileIO.scala
@@ -1,7 +1,29 @@
 package org.gwalid.seq.datasource.v2
 
+import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 
 class SeqInputFileIO(path: String) extends Serializable {
-  def getPath(): Path = new Path(path)
+
+  private lazy val currentPath: Path = new Path(path)
+  private lazy val sizeInBytes = computeSizeInBytes()
+
+  def getPath: Path = currentPath
+
+  def getSizeInByte: Long = sizeInBytes
+
+  def computeSizeInBytes(): Long = {
+
+    val conf = new Configuration() // Fixme: Get it from SparkSession instead
+    val fs = currentPath.getFileSystem(conf)
+    fs.listStatus(currentPath).head.getLen
+  }
+
+  def getNumRows: Int = {
+    // Estimates the number of rows: We divide the total size by 30 Bytes
+    math.ceil(sizeInBytes / 30).toInt
+  }
+
+
+
 }

--- a/src/main/scala/org/gwalid/seq/datasource/v2/SeqInputPartitionReader.scala
+++ b/src/main/scala/org/gwalid/seq/datasource/v2/SeqInputPartitionReader.scala
@@ -29,7 +29,7 @@ class SeqInputPartitionReader(seqInputFile: SeqInputFileIO)
 
   private def getReader: SequenceFile.Reader = {
 
-    val fileOption = SequenceFile.Reader.file(seqInputFile.getPath())
+    val fileOption = SequenceFile.Reader.file(seqInputFile.getPath)
 
     new SequenceFile.Reader(conf, fileOption)
 


### PR DESCRIPTION
This PR resolves the following items:

- adds supportsReportStatistics, it's based on estimating the number of rows of the sequence file.  
The number of rows is the total size in Bytes divided by 30 Bytes.   
**Note:** The 30 Bytes is chosen based on some data observations. 

- Add `scalastyle-maven-plugin` to test phase.